### PR TITLE
Support `body` field in `mailto:` URI

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -691,7 +691,9 @@ class UnsubMail extends UnsubMethod {
       subject: this.email.searchParams.has('subject')
         ? this.email.searchParams.get('subject')
         : 'unsubscribe',
-      body: 'Please unsubscribe me from your mailing list. Thank you.',
+      body: this.email.searchParams.has('body')
+        ? this.email.searchParams.get('body')
+        : 'Please unsubscribe me from your mailing list. Thank you.',
     };
 
     if (this.identity) {


### PR DESCRIPTION
The `List-Unsubscribe` header value may contain a `mailto:` URI with the `body` field in it, like `mailto:unsubscribe@example.com?body=foo`, which indicates that the message body should be <q>foo</q>. This patch adds support for that field.

The `body` field is defined in [RFC 6068] (<cite>The 'mailto' URI Scheme</cite>) as the following:

>    The special <hfname> "body" indicates that the associated &lt;hfvalue&gt;
   is the body of the message.  The "body" field value is intended to
   contain the content for the first text/plain body part of the
   message. […]

The RFC also states:

> […] Clients
   that resolve 'mailto' URIs into mail messages MUST be able to
   correctly create [RFC5322]-compliant mail messages using the
   "subject" header field and "body".

[RFC 6068]: <https://www.rfc-editor.org/rfc/rfc6068>